### PR TITLE
fix: Updates aws-s3-list-bucket-names to only output the names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Playing with scripts.
 
 1. Get the list of buckets:
 ```shell
-# It will create a 'buckets.txt' by default
+# It will create a '/tmp/utils-cli-bin-aws-s3-list-bucket-names.log' by default
 ./bin/aws-s3-list-bucket-names.sh
 
 # Changing the output file
-BUCKET_NAMES_FILE=output.txt ./bin/aws-s3-list-bucket-names.sh
+BUCKETS_LIST_FILE=output.txt ./bin/aws-s3-list-bucket-names.sh
 ```
 
 2. Edit the output file in order to have only one bucket name per line:
@@ -25,7 +25,7 @@ my-bucket-02
 3. Check the desired tag against the bucket list:
 
 ```shell
-# Defaults to TAG_NAME=backup_tier TAG_VALUE=class_a BUCKET_NAMES_FILE=buckets.txt
+# Defaults to TAG_NAME=backup_tier TAG_VALUE=class_a BUCKETS_LIST_FILE=/tmp/utils-cli-bin-aws-s3-list-bucket-names.log
 ./bin/aws-s3-check-bucket-tag.sh
 # Buckets with tag 'backup_tier=class_a':
 # ❌ bucket-1
@@ -36,6 +36,6 @@ my-bucket-02
 TAG_NAME=tag TAG_VALUE=value ./bin/aws-s3-check-bucket-tag.sh
 
 # Using another file
-BUCKET_NAMES_FILE=output.txt ./bin/aws-s3-check-bucket-tag.sh
+BUCKETS_LIST_FILE=output.txt ./bin/aws-s3-check-bucket-tag.sh
 ```
 

--- a/bin/aws-s3-list-bucket-names.sh
+++ b/bin/aws-s3-list-bucket-names.sh
@@ -1,9 +1,29 @@
 #!/bin/bash
 
-set -e
+# For log purpose when runned remotely (e.g., GitHub raw content URL)
+SERVICE=utils-cli-bin-aws-s3-list-bucket-names
 
-BUCKET_NAMES_FILE="${BUCKET_NAMES_FILE:-buckets.txt}"
+# Args
+BUCKETS_LIST_FILE="${BUCKETS_LIST_FILE:-/tmp/${SERVICE}.log}"
 
-aws s3api list-buckets --query "Buckets[].Name" --output table >$BUCKET_NAMES_FILE
+# Output
+OUTPUT_FILE=${BUCKETS_LIST_FILE}
 
-echo "List of buckets saved to '$BUCKET_NAMES_FILE'"
+# Main command
+response=$(aws s3api list-buckets --query "Buckets[].Name" --output json --no-cli-pager)
+response_code=$?
+
+# Error
+if [[ "${response_code}" != '0' ]]; then
+    echo "${response}" >${OUTPUT_FILE}
+    echo "Service: ${SERVICE}"
+    echo "Error: code=${response_code} ${response}"
+    echo "Logs saved to: '${OUTPUT_FILE}'"
+    exit 1
+fi
+
+# Success
+# gets just the bucket names
+OUTPUT=$(echo "${response}" | jq -r '.[]')
+# print the result and save it in a file
+echo "${OUTPUT}" | tee ${OUTPUT_FILE}


### PR DESCRIPTION
## Context

- print the list of buckets
- save the result to a file

closes #1

## Refs
<!--
Note: List of related links and updated docs (READMEs, Notion, Google Docs, others links, etc).
-->

- [README](/DavidCardoso/utils-cli#readme)
