### PR TITLE
fix(#5): Adds extended regex format to grep command in list-bucket-names script

### DIFF
--- a/bin/aws-s3-list-bucket-names.sh
+++ b/bin/aws-s3-list-bucket-names.sh
@@ -28,6 +28,6 @@ fi
 
 # Success
 # gets just the bucket names
-OUTPUT=$(echo "${response}" | jq -r '.[]' | grep "${BUCKET_NAME_FILTER}")
+OUTPUT=$(echo "${response}" | jq -r '.[]' | grep -E "${BUCKET_NAME_FILTER}")
 # prints the result and save it in a file
 echo "${OUTPUT}" | tee ${OUTPUT_FILE}


### PR DESCRIPTION
closes #5 
