### PR TITLE
Feat/fetch s3 bucket object details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 Playing with scripts.
 
+- [Utilities via CLI](#utilities-via-cli)
+  - [Usage examples](#usage-examples)
+    - [Getting the list of AWS S3 buckets:](#getting-the-list-of-aws-s3-buckets)
+    - [Checking if a tag exists in an AWS S3 Bucket:](#checking-if-a-tag-exists-in-an-aws-s3-bucket)
+    - [Getting AWS S3 bucket details](#getting-aws-s3-bucket-details)
+    - [Getting AWS S3 bucket lock config](#getting-aws-s3-bucket-lock-config)
+    - [Getting AWS S3 object details](#getting-aws-s3-object-details)
+
 ## Usage examples
 
-### Getting the list of buckets:
+### Getting the list of AWS S3 buckets:
 ```shell
 # It will create a '/tmp/utils-cli-bin-aws-s3-list-bucket-names.log' by default
 ./bin/aws-s3-list-bucket-names.sh
@@ -33,3 +41,24 @@ TAG_NAME=tag TAG_VALUE=value ./bin/aws-s3-check-bucket-tag.sh
 BUCKETS_LIST_FILE=output.txt ./bin/aws-s3-check-bucket-tag.sh
 ```
 
+### Getting AWS S3 bucket details
+
+```shell
+BUCKET_NAME='bucket-name' ./bin/aws-s3-get-bucket-details.sh
+```
+
+### Getting AWS S3 bucket lock config
+
+```shell
+BUCKET_NAME='bucket-name' ./bin/aws-s3-get-bucket-lock-config.sh
+```
+
+### Getting AWS S3 object details
+
+```shell
+# Folders
+BUCKET_NAME='bucket-name' OBJECT_KEY='my/folder/' ./bin/aws-s3-get-object-details.sh
+
+# Files
+BUCKET_NAME='bucket-name' OBJECT_KEY='my/folder/file.txt' ./bin/aws-s3-get-object-details.sh
+```

--- a/bin/aws-s3-get-bucket-details.sh
+++ b/bin/aws-s3-get-bucket-details.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-# Check if the bucket name arguments are provided
-if [ -z "$1" ]; then
-    echo "Usage: $0 <bucket-name>"
+# Check environment variables
+if [ -z "$BUCKET_NAME" ]; then
+    echo "Error: BUCKET_NAME is not provided"
     exit 1
 fi
-
-BUCKET_NAME=$1
-OBJECT_KEY=$2
 
 # Get Details for the bucket
 echo "// Head Bucket "

--- a/bin/aws-s3-get-bucket-details.sh
+++ b/bin/aws-s3-get-bucket-details.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Check if the bucket name arguments are provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <bucket-name>"
+    exit 1
+fi
+
+BUCKET_NAME=$1
+OBJECT_KEY=$2
+
+# Get Details for the bucket
+echo "// Head Bucket "
+aws s3api head-bucket --bucket "$BUCKET_NAME"
+
+echo
+echo "// Lifecycle Configuration"
+aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET_NAME"

--- a/bin/aws-s3-get-bucket-lock-config.sh
+++ b/bin/aws-s3-get-bucket-lock-config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Check if the bucket name argument is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <bucket-name>"
+    exit 1
+fi
+
+BUCKET_NAME=$1
+
+# Get Object Lock Configuration for the bucket
+aws s3api get-object-lock-configuration --bucket "$BUCKET_NAME"

--- a/bin/aws-s3-get-bucket-lock-config.sh
+++ b/bin/aws-s3-get-bucket-lock-config.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-# Check if the bucket name argument is provided
-if [ -z "$1" ]; then
+# Check environment variables
+if [ -z "$BUCKET_NAME" ]; then
     echo "Usage: $0 <bucket-name>"
     exit 1
 fi
-
-BUCKET_NAME=$1
 
 # Get Object Lock Configuration for the bucket
 aws s3api get-object-lock-configuration --bucket "$BUCKET_NAME"

--- a/bin/aws-s3-get-object-details.sh
+++ b/bin/aws-s3-get-object-details.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Check if the bucket name and object key arguments are provided
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Usage: $0 <bucket-name> <object-key>"
+    echo "Note: to check a folder, use the object key with a trailing slash: my/folder/"
+    exit 1
+fi
+
+BUCKET_NAME=$1
+OBJECT_KEY=$2
+
+# Get Object Lock Details for the specific object
+aws s3api head-object --bucket "$BUCKET_NAME" --key "$OBJECT_KEY"

--- a/bin/aws-s3-get-object-details.sh
+++ b/bin/aws-s3-get-object-details.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-# Check if the bucket name and object key arguments are provided
-if [ -z "$1" ] || [ -z "$2" ]; then
-    echo "Usage: $0 <bucket-name> <object-key>"
-    echo "Note: to check a folder, use the object key with a trailing slash: my/folder/"
+# Check environment variables
+if [ -z "$BUCKET_NAME" ]; then
+    echo "Error: BUCKET_NAME is not provided"
     exit 1
 fi
 
-BUCKET_NAME=$1
-OBJECT_KEY=$2
+if [ -z "$OBJECT_KEY" ]; then
+    echo "Error: OBJECT_KEY is not provided"
+    echo "Note: to check a folder, use the object key with a trailing slash: my/folder/"
+    exit 1
+fi
 
 # Get Object Lock Details for the specific object
 aws s3api head-object --bucket "$BUCKET_NAME" --key "$OBJECT_KEY"


### PR DESCRIPTION
## Context

In some cases, we can't properly get some information from S3 objects easily like accessing the console. For example, object lock information can't be seeing in the console for empty folders. 

- [x] adds get-bucket-details script
- [x] adds get-object-details script
- [x] adds get-bucket-lock-config script

## Refs
<!--
Note: List of related links and updated docs (READMEs, Notion, Google Docs, others links, etc).
-->

- [README](/DavidCardoso/utils-cli#readme)
